### PR TITLE
Ignore spaces before trailer

### DIFF
--- a/core/lib/Pdf/Core/Parsers/XRef.hs
+++ b/core/lib/Pdf/Core/Parsers/XRef.hs
@@ -76,6 +76,7 @@ parseSubsectionHeader = do
 -- Input position should point to the \"trailer\" keyword
 parseTrailerAfterTable :: Parser Dict
 parseTrailerAfterTable = do
+  P.skipSpace
   _ <- P.string "trailer"
   endOfLine
   P.skipSpace


### PR DESCRIPTION
I've found a couple of pdf files for which this fix is necessary.