### PR TITLE
fixed character encoding for Type0 fonts (FontInfoComposite)

### DIFF
--- a/content/lib/Pdf/Content/FontInfo.hs
+++ b/content/lib/Pdf/Content/FontInfo.hs
@@ -229,15 +229,17 @@ cmapDecodeString
   -> [(Glyph, Double)]
 cmapDecodeString getWidth cmap str = go str
   where
-  go s =
-    case unicodeCMapNextGlyph cmap s of
-      Nothing -> []
-      Just (g, rest) ->
-        let width = getWidth g / 1000
-            glyph = Glyph {
-          glyphCode = g,
-          glyphTopLeft = Vector 0 0,
-          glyphBottomRight = Vector width 1,
-          glyphText = unicodeCMapDecodeGlyph cmap g
-          }
-        in (glyph, width) : go rest
+    (eatNext, decodeFun) = unicodeCMapNextGlyph cmap
+    go s =
+      case eatNext s of
+        Nothing -> []
+        Just (g, rest) ->
+          let i = toCode g
+              width = getWidth i / 1000
+              glyph = Glyph {
+                glyphCode = i,
+                glyphTopLeft = Vector 0 0,
+                glyphBottomRight = Vector width 1,
+                glyphText = unicodeCMapDecodeGlyphWith cmap decodeFun g
+                }
+          in (glyph, width) : go rest

--- a/content/lib/Pdf/Content/UnicodeCMap.hs
+++ b/content/lib/Pdf/Content/UnicodeCMap.hs
@@ -1,13 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Unicode CMap defines mapping from glyphs to text
+-- | Unicode CMap defines mapping from glyphs to text.
+--
+-- Technical specs can be found here:
+-- (1) https://www.adobe.com/content/dam/acom/en/devnet/font/pdfs/5099.CMapResources.pdf
+-- and p. 48 seqq of
+-- (2) https://www.adobe.com/content/dam/acom/en/devnet/font/pdfs/5014.CIDFont_Spec.pdf
+-- see also:
+-- (3) https://github.com/adobe-type-tools/cmap-resources
+
 
 module Pdf.Content.UnicodeCMap
 (
   UnicodeCMap(..),
   parseUnicodeCMap,
   unicodeCMapNextGlyph,
-  unicodeCMapDecodeGlyph
+  unicodeCMapDecodeGlyphWith,
+  unicodeCMapDecodeGlyph,
+  toCode
 )
 where
 
@@ -25,6 +35,7 @@ import Data.Attoparsec.ByteString.Char8 (Parser, parseOnly)
 import qualified Data.Attoparsec.ByteString.Char8 as P
 import Control.Monad
 import qualified Control.Monad.Fail as Fail
+import Data.Word (Word8)
 
 -- | Unicode character map
 --
@@ -54,38 +65,102 @@ parseUnicodeCMap cmap =
   chars = parseOnly charsParser cmap
   ranges = parseOnly rangesParser cmap
 
--- | Take the next glyph code from string, also returns the rest of the string
-unicodeCMapNextGlyph :: UnicodeCMap -> ByteString -> Maybe (Int, ByteString)
-unicodeCMapNextGlyph cmap = go 1
+-- | Return a pair of functions: One that takes the next glyph code
+-- from string and also returns the rest of the string, and a second
+-- that decodes a byte string to text.
+unicodeCMapNextGlyph :: UnicodeCMap -> ((ByteString -> Maybe (ByteString, ByteString)),
+                                        (ByteString -> Maybe Text))
+unicodeCMapNextGlyph (UnicodeCMap rs@[("\x00\x00","\xFF\xFF")] _ _) =
+  -- UCS-2, according to (1)
+  ((fixedWidthMultiByte 2 rs), (Just . decodeUcs2))
+unicodeCMapNextGlyph (UnicodeCMap rs@[ ("\x00\x00","\xD7\xFF")
+                                     , ("\xE0\x00","\xFF\xFF")] _ _) =
+  -- UCS-2, according to (2)
+  ((fixedWidthMultiByte 2 rs), (Just . decodeUcs2))
+unicodeCMapNextGlyph (UnicodeCMap rs@[("\x00\x00\x00\x00","\x00\x10\xFF\xFF")] _ _) =
+  -- UTF32 (UTF32-BE)
+  ((fixedWidthMultiByte 4 rs), (Just . Text.decodeUtf32BE))
+unicodeCMapNextGlyph (UnicodeCMap rs@[ ("\x00\x00","\xD7\FF")
+                                     , ("\xE0\x00","\xFF\xFF")
+                                     , ("\xD8\x00\xDC\x00", "\xDB\xFF\xDF\xFF")] _ _) =
+  -- UTF16 (UTF16-BE)
+  ((variableWidthMultiByte 2 2 6 rs), (Just . Text.decodeUtf16BE))
+unicodeCMapNextGlyph (UnicodeCMap rs@[ ("\x00","\xFF")] _ _) =
+  -- 8 Bit encodings (assuming Latin1)
+  ((fixedWidthMultiByte 1 rs), (Just . Text.decodeLatin1))
+-- -- TODO: add more encodings: ISO 2022, EUC-TW, Big Five, see (3)
+unicodeCMapNextGlyph (UnicodeCMap rs _ _) =
+  -- Default: This works for UTF8 and 7 Bit encodings.
+  ((variableWidthMultiByte 1 1 5 rs), ((either (const Nothing) Just) . Text.decodeUtf8'))
+
+
+fixedWidthMultiByte :: Int -> [(ByteString, ByteString)] -> ByteString -> Maybe (ByteString, ByteString)
+fixedWidthMultiByte l ranges bs =
+  if ByteString.length bs >= l && inCMapRanges ranges bs
+  then Just (ByteString.take l bs, ByteString.drop l bs)
+  else Nothing
+
+variableWidthMultiByte :: Int   -- ^ length in bytes to start with
+                       -> Int   -- ^ length delta between steps
+                       -> Int   -- ^ length at which to stop eating bytes
+                       -> [(ByteString, ByteString)] -- ^ code space ranges
+                       -> ByteString                 -- ^ string to eat and decode
+                       -> Maybe (ByteString, ByteString)
+variableWidthMultiByte startLength step stopLength ranges = go startLength
   where
-  go 5 _ = Nothing
-  go n str =
-    let glyph = ByteString.take n str in
-    if ByteString.length glyph /= n
-      then Nothing
-      else if any (inRange glyph) (unicodeCMapCodeRanges cmap)
-             then Just (toCode glyph, ByteString.drop n str)
-             else go (n + 1) str
-  inRange glyph (start, end) = glyph >= start && glyph <= end
+    go n str =
+      let glyph = ByteString.take n str in
+        if ByteString.length glyph /= n || n >= stopLength
+        then Nothing
+        else if inCMapRanges ranges glyph
+             then Just (glyph, ByteString.drop n str)
+             else go (n + step) str
+
+inCMapRanges :: [(ByteString, ByteString)] -> ByteString -> Bool
+inCMapRanges ranges bs = any (inRange bs) ranges
+  where
+    inRange bs' (start, end) = bs' >= start && bs' <= end
 
 toCode :: ByteString -> Int
 toCode bs = fst $ ByteString.foldr (\b (sm, i) ->
-                    (sm + fromIntegral b * i, i * 255)) (0, 1) bs
+                    (sm + fromIntegral b * i, i * 256)) (0, 1) bs
+
+intToByteString :: Int -> ByteString
+intToByteString = ByteString.pack . reverse . intToByteString'
+  where
+    intToByteString' :: Int -> [Word8]
+    intToByteString' i
+      | i `div` 256 == 0 = (fromIntegral $ i `mod` 256):[]
+      | otherwise = (fromIntegral $ i `mod` 256):(intToByteString' (i `div` 256))
+
+-- | Decode a *single character* represented as a 'ByteString' to
+-- 'Text' mapping the full character range from 0x0000 to 0xFFFF
+-- (different from 'Text.decodeUtf16BE'). Big endian is assumed. This
+-- decoding function works for UCS-2. It even works for single byte
+-- encodings, where it equals to ISO8859-1 (Latin1). It would even
+-- work for UCS-4.
+decodeUcs2 :: ByteString -> Text
+decodeUcs2 = Text.singleton . toEnum . toCode
 
 -- | Convert glyph to text
 --
 -- Note: one glyph can represent more then one char, e.g. for ligatures
-unicodeCMapDecodeGlyph :: UnicodeCMap -> Int -> Maybe Text
-unicodeCMapDecodeGlyph cmap glyph =
-  case Map.lookup glyph (unicodeCMapChars cmap) of
+unicodeCMapDecodeGlyphWith :: UnicodeCMap -> (ByteString -> Maybe Text) -> ByteString -> Maybe Text
+unicodeCMapDecodeGlyphWith cmap decodeFun glyph =
+  case Map.lookup glyphInt (unicodeCMapChars cmap) of
     Just txt -> Just txt
     Nothing ->
       case filter inRange (unicodeCMapRanges cmap) of
-        [(start, _, char)] -> Just (Text.singleton $ toEnum
-                                    $ (fromEnum char) + (glyph - start))
+        [(0, _, '\x00')] -> decodeFun glyph
+        [(start, _, char)] -> decodeFun $ intToByteString $ (fromEnum char) + (glyphInt - start)
         _ -> Nothing
   where
-  inRange (start, end, _) = glyph >= start && glyph <= end
+  glyphInt = toCode glyph
+  inRange (start, end, _) = glyphInt >= start && glyphInt <= end
+
+unicodeCMapDecodeGlyph :: UnicodeCMap -> Int -> Maybe Text
+unicodeCMapDecodeGlyph cmap =
+  (unicodeCMapDecodeGlyphWith cmap (Just . decodeUcs2)) . intToByteString
 
 charsParser :: Parser (Map Int Text)
 charsParser =
@@ -157,6 +232,7 @@ codeRangesParser = do
     void $ P.string "begincodespacerange"
     return n
 
+  -- FIXME: in the specs this is limited to 100 in order to avoid stack overflows
   replicateM n $ do
     P.skipSpace
     i <- parseHex

--- a/content/test/Test/UnicodeCMap.hs
+++ b/content/test/Test/UnicodeCMap.hs
@@ -50,7 +50,7 @@ parseUnicodeCMapSpec = describe "parseUnicodeCMap" $ do
           ]
         res = parseUnicodeCMap input
     fmap unicodeCMapChars res `shouldBe`
-      Right (Map.fromList [(14871,"\131134")])
+      Right (Map.fromList [(14929,"\131134")])
 
   it "should parse multiple chars" $ do
     let input = ByteString.concat


### PR DESCRIPTION
This fixes #55.

Following Adobe's Tutorial on [CMap Resources](https://www.adobe.com/content/dam/acom/en/devnet/font/pdfs/5099.CMapResources.pdf) and the [specs](https://www.adobe.com/content/dam/acom/en/devnet/font/pdfs/5014.CIDFont_Spec.pdf), when there is a character range like this

    1 begincodespacerange
    <0000> <FFFF>
    endcodespacerange

*two bytes* encode one character.

The implementation at least of `unicodeCMapNextGlyph` tried to read one single byte first, and if the range test fails, reads a second (and a third and fourth byte). This works for UTF-8 and 7 Bit encodings, but not for fixed with multi-byte encodings like UCS-2 or UTF-32. Even with UTF-16 it fails. Not only the "eating" of the next glyph by `unicodeCMapNextGlyph` and range testing is an issue, but also the decoding of the returned integer into `Text`. This was simply always done by applying the concatenation of `Text.singleton . toEnum` to an integer code. But this is not always correct, instead the encoding must be considered. E.g. after having read 4 bytes of a UTF-8 encoding, these bytes can be simply decoded with this mechanism, but must encoded regarding the transformation format by using `Text.Encoding.decodeUtf8` for example.

In order to fix these two issues I have re-implemented `unicodeCMapNextGlyph`. It was used in partial evaluation on the CMap as a closure to which a ByteString was feed. Now it returns a pair of functions for a CMap instead. The first is the function for eating the next glyph and returning it and the rest (like the old closure). The second is a function for decoding the glyph's bytestring-representation correctly.

The old implementation of `unicodeCMapNextGlyph` has gone to `variableWidthMultiByte`, which has be made more generic to work with different encodings, e.g. UTF-8 or UTF-16. There is also a new counterpart for fixed-width multi-byte encodings.

The functions that call `unicodeCMapNextGlyph` or evaluate its return values have been changed, too: `cmapDecodeString` and `unicodeCMapDecodeGlyph`. `unicodeCMapDecodeGlyph` now is mostly replaced by `unicodeCMapDecodeGlyphWith` which also takes the decoding function that was returned by the new `unicodeCMapNextGlyph`. Since the old `unicodeCMapDecodeGlyph` was also called outside of `cmapDecodeString` form `fontInfoDecodeGlyphs` for simple font infos, it still exists with it's old signature. But I think that this use is still buggy and `cmapDecodeString` should be used in this place, too. -- I could write a further fix for this.

The glyph-eater function returned by `unicodeCMapNextGlyph` now returns a pair of byte strings (glyph and rest), not an integer and a byte string like the old `unicodeCMapNextGlyph`. This makes sense because in reality we do not have to convert byte strings and integers forth and back most of the times, because the bfranges is often of the form <00> <...> <00>, where no correction has to be done. That's why I have added pattern matching for this case in `unicodeCMapDecodeGlyphWith`.

There was also a little bug in `toCode`, which I fixed.

I've tried to add more encodings to `unicodeCMapNextGlyph` using the `encoding` package. But there is only one relevant decoder in it, for ISO2022-JP. So I left it away, because the compilation time gets very long and it causes "cabal hell" for the project where I use pdf-toolbox.




From the commit message:

- rewrite of unicodeCMapNextGlyph and the functions calling it
  (cmapDecodeString): Its signature has been changed and it now
  returns two functions: a function for eating bytes and a function
  for decoding these eaten bytes. Both functions must be deduced from
  the character ranges defined in the CMap and they must match to each
  other.

- old code of unicodeCMapNextGlyph has gone into
  variableWidthMultiByte

- added a new function unicodeCMapDecodeGlyphWith that takes a
  decoding function (returned by unicodeCMapNextGlyph), since the
  decoding mechanism of the old implementation is not appropriate for
  some glyph encodings. It replaces the old unicodeCMapDecodeGlyph in
  most places. unicodeCMapDecodeGlyph now is based on this new
  function and is still present for compatibility reasons. (It is
  still called from fontInfoDecodeGlyphs with a FontInfoSimple.)

- added some new helper functions

- fixed toCode and a test case