### PR TITLE
Fix unicode cmap handling

### DIFF
--- a/content/lib/Pdf/Content/UnicodeCMap.hs
+++ b/content/lib/Pdf/Content/UnicodeCMap.hs
@@ -66,11 +66,13 @@ unicodeCMapNextGlyph cmap = go 1
       else if any (inRange glyph) (unicodeCMapCodeRanges cmap)
              then Just (toCode glyph, ByteString.drop n str)
              else go (n + 1) str
-  inRange glyph (start, end) = glyph >= start && glyph <= end
+  inRange glyph (start, end)
+    = ByteString.length glyph == ByteString.length start
+    && glyph >= start && glyph <= end
 
 toCode :: ByteString -> Int
 toCode bs = fst $ ByteString.foldr (\b (sm, i) ->
-                    (sm + fromIntegral b * i, i * 255)) (0, 1) bs
+                    (sm + fromIntegral b * i, i * 256)) (0, 1) bs
 
 -- | Convert glyph to text
 --

--- a/content/test/Test/UnicodeCMap.hs
+++ b/content/test/Test/UnicodeCMap.hs
@@ -18,6 +18,7 @@ spec :: Spec
 spec = describe "UnicodeCMap" $ do
   parseUnicodeCMapSpec
   unicodeCMapDecodeGlyphSpec
+  unicodeCMapNextGlyphSpec
 
 parseUnicodeCMapSpec :: Spec
 parseUnicodeCMapSpec = describe "parseUnicodeCMap" $ do
@@ -153,3 +154,11 @@ unicodeCMapDecodeGlyphSpec = describe "unicodeCMapDecodeGlyph" $ do
 
     let res = unicodeCMapDecodeGlyph cmap 16
     res `shouldBe` Nothing
+
+unicodeCMapNextGlyphSpec :: Spec
+unicodeCMapNextGlyphSpec = describe "unicodeCMapNextGlyph" $ do
+  it "correctly handles multibyte ranges" $ do
+    let cmap = UnicodeCMap [("\0\0", "\1\1")] mempty []
+    let Just (code, rest) = unicodeCMapNextGlyph cmap "\1\0rest"
+    rest `shouldBe` rest
+    code `shouldBe` 256

--- a/content/test/Test/UnicodeCMap.hs
+++ b/content/test/Test/UnicodeCMap.hs
@@ -50,7 +50,7 @@ parseUnicodeCMapSpec = describe "parseUnicodeCMap" $ do
           ]
         res = parseUnicodeCMap input
     fmap unicodeCMapChars res `shouldBe`
-      Right (Map.fromList [(14871,"\131134")])
+      Right (Map.fromList [(14929,"\131134")])
 
   it "should parse multiple chars" $ do
     let input = ByteString.concat


### PR DESCRIPTION
Fix a typo in toCode
Consume the correct number of bytes in unicodeCMapNextGlyph

Related to #55 

Thanks to @lueck for uncovering the bugs.