### PR TITLE
Put uses of zlib behind a flag

### DIFF
--- a/core/lib/Pdf/Core/Stream.hs
+++ b/core/lib/Pdf/Core/Stream.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE  OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 
@@ -18,7 +19,9 @@ import Pdf.Core.Exception
 import Pdf.Core.Object
 import Pdf.Core.Parsers.Object
 import Pdf.Core.Stream.Filter.Type
+#ifdef ENABLE_ZLIB
 import Pdf.Core.Stream.Filter.FlateDecode
+#endif
 import Pdf.Core.IO.Buffer (Buffer)
 import qualified Pdf.Core.IO.Buffer as Buffer
 
@@ -50,9 +53,18 @@ readStream is off = do
 
 -- | All stream filters implemented by the toolbox
 --
+#ifdef ENABLE_ZLIB
 -- Right now it contains only FlateDecode filter
+#else
+-- Right now it contains no filters
+#endif
 knownFilters :: [StreamFilter]
-knownFilters = [flateDecode]
+knownFilters =
+#ifdef ENABLE_ZLIB
+  [flateDecode]
+#else
+  []
+#endif
 
 -- | Raw stream content.
 -- Filters are not applyed

--- a/core/pdf-toolbox-core.cabal
+++ b/core/pdf-toolbox-core.cabal
@@ -28,6 +28,11 @@ source-repository head
   type:                git
   location:            git://github.com/Yuras/pdf-toolbox.git
 
+flag zlib
+  description: Enable deflate support via zlib; requires that the Zlib flag be set on io-streams
+  default: True
+  manual: True
+
 library
   hs-source-dirs:      lib
                        compat
@@ -45,7 +50,6 @@ library
                        Pdf.Core.Parsers.Util
                        Pdf.Core.Stream
                        Pdf.Core.Stream.Filter.Type
-                       Pdf.Core.Stream.Filter.FlateDecode
                        Pdf.Core.XRef
                        Pdf.Core.Util
                        Pdf.Core.Writer
@@ -67,6 +71,8 @@ library
                        cipher-aes,
                        crypto-api,
                        cryptohash
+  if flag(zlib)
+    exposed-modules:   Pdf.Core.Stream.Filter.FlateDecode
 
 test-suite test
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
This allows the library to be built for other platforms, such as ghcjs