### PR TITLE
parse FontDescriptor and use FontBBox for y-coordinates of glyphs

### DIFF
--- a/content/lib/Pdf/Content.hs
+++ b/content/lib/Pdf/Content.hs
@@ -8,6 +8,7 @@ module Pdf.Content
 , module Pdf.Content.Processor
 , module Pdf.Content.Transform
 , module Pdf.Content.FontInfo
+, module Pdf.Content.FontDescriptor
 )
 where
 
@@ -17,3 +18,4 @@ import Pdf.Content.UnicodeCMap
 import Pdf.Content.Processor
 import Pdf.Content.Transform
 import Pdf.Content.FontInfo
+import Pdf.Content.FontDescriptor

--- a/content/lib/Pdf/Content/FontDescriptor.hs
+++ b/content/lib/Pdf/Content/FontDescriptor.hs
@@ -6,19 +6,18 @@ module Pdf.Content.FontDescriptor
   ( FontDescriptor(..)
   , FontDescriptorFlag(..)
   , flagSet
-  , flagSet'
   )
 where
 
 import Pdf.Core.Types
 
-import Data.Text (Text)
 import Data.Int
+import Data.ByteString (ByteString)
 
 data FontDescriptor = FontDescriptor {
-  fdFontName :: Text,
-  fdFontFamily :: Maybe Text,
-  fdFontStretch :: Maybe Text,
+  fdFontName :: ByteString,
+  fdFontFamily :: Maybe ByteString,
+  fdFontStretch :: Maybe ByteString,
   fdFontWeight :: Maybe Int,
   fdFlags :: Int64, -- must hold at least 32 bit unsigned integers
   fdFontBBox :: Maybe (Rectangle Double),
@@ -34,7 +33,7 @@ data FontDescriptor = FontDescriptor {
   fdMaxWidth :: Maybe Double,
   fdMissingWidth :: Maybe Double,
   -- FIXME: add FontFile*
-  fdCharSet :: Maybe Text
+  fdCharSet :: Maybe ByteString
   -- FIXME: add special fields for CIDFonts
   } deriving (Show)
 
@@ -55,7 +54,7 @@ flagSet fd SmallCap = flagSet' 18 (fdFlags fd) 0
 flagSet fd ForceBold = flagSet' 19 (fdFlags fd) 0
 
 flagSet' :: Int -> Int64 -> Int -> Bool
-flagSet' pos val exp
-  | exp == pos - 1 = val `mod` 2 == 1
+flagSet' pos val expnt
+  | expnt == pos - 1 = val `mod` 2 == 1
   | val == 0 = False
-  | otherwise = flagSet' pos (val `div` 2) (exp+1)
+  | otherwise = flagSet' pos (val `div` 2) (expnt+1)

--- a/content/lib/Pdf/Content/FontDescriptor.hs
+++ b/content/lib/Pdf/Content/FontDescriptor.hs
@@ -1,0 +1,61 @@
+
+-- | The FontDescriptor describes a font's other metrics than it's
+-- widths, see chap. 9.8 of PDF32000:2008
+
+module Pdf.Content.FontDescriptor
+  ( FontDescriptor(..)
+  , FontDescriptorFlag(..)
+  , flagSet
+  , flagSet'
+  )
+where
+
+import Pdf.Core.Types
+
+import Data.Text (Text)
+import Data.Int
+
+data FontDescriptor = FontDescriptor {
+  fdFontName :: Text,
+  fdFontFamily :: Maybe Text,
+  fdFontStretch :: Maybe Text,
+  fdFontWeight :: Maybe Int,
+  fdFlags :: Int64, -- must hold at least 32 bit unsigned integers
+  fdFontBBox :: Maybe (Rectangle Double),
+  fdItalicAngle :: Double,
+  fdAscent :: Maybe Double,
+  fdDescent :: Maybe Double,
+  fdLeading :: Maybe Double,
+  fdCapHeight :: Maybe Double,
+  fdXHeight :: Maybe Double,
+  fdStemV :: Maybe Double,
+  fdStemH :: Maybe Double,
+  fdAvgWidth :: Maybe Double,
+  fdMaxWidth :: Maybe Double,
+  fdMissingWidth :: Maybe Double,
+  -- FIXME: add FontFile*
+  fdCharSet :: Maybe Text
+  -- FIXME: add special fields for CIDFonts
+  } deriving (Show)
+
+
+data FontDescriptorFlag =
+  FixedPitch | Serif | Symbolic | Script | NonSymbolic | Italic | AllCap | SmallCap | ForceBold
+
+
+flagSet :: FontDescriptor -> FontDescriptorFlag -> Bool
+flagSet fd FixedPitch = flagSet' 1 (fdFlags fd) 0
+flagSet fd Serif = flagSet' 2 (fdFlags fd) 0
+flagSet fd Symbolic = flagSet' 3 (fdFlags fd) 0
+flagSet fd Script = flagSet' 4 (fdFlags fd) 0
+flagSet fd NonSymbolic = flagSet' 6 (fdFlags fd) 0
+flagSet fd Italic = flagSet' 7 (fdFlags fd) 0
+flagSet fd AllCap = flagSet' 17 (fdFlags fd) 0
+flagSet fd SmallCap = flagSet' 18 (fdFlags fd) 0
+flagSet fd ForceBold = flagSet' 19 (fdFlags fd) 0
+
+flagSet' :: Int -> Int64 -> Int -> Bool
+flagSet' pos val exp
+  | exp == pos - 1 = val `mod` 2 == 1
+  | val == 0 = False
+  | otherwise = flagSet' pos (val `div` 2) (exp+1)

--- a/content/pdf-toolbox-content.cabal
+++ b/content/pdf-toolbox-content.cabal
@@ -28,6 +28,7 @@ library
                        Pdf.Content.Processor
                        Pdf.Content.Transform
                        Pdf.Content.UnicodeCMap
+                       Pdf.Content.FontDescriptor
                        Pdf.Content.FontInfo
                        Pdf.Content.GlyphList
                        Pdf.Content.TexGlyphList
@@ -55,6 +56,7 @@ test-suite test
   main-is:             test.hs
   other-modules:       Test.UnicodeCMap
                        Test.Parser
+                       Test.FontDescriptor
                        Prelude
                        Data.Either
   build-depends:       base,

--- a/content/test/Test/FontDescriptor.hs
+++ b/content/test/Test/FontDescriptor.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.FontDescriptor
+(
+  spec,
+)
+where
+
+import Pdf.Content.FontDescriptor
+
+import Data.Int
+import Test.Hspec
+
+spec :: Spec
+spec = describe "FontDescriptor" $ do
+  testFlagSet
+
+defFD :: FontDescriptor
+defFD = FontDescriptor
+  { fdFontName = "test"
+  , fdFontFamily = Nothing
+  , fdFontStretch = Nothing
+  , fdFontWeight = Nothing
+  , fdFlags = 5
+  , fdFontBBox = Nothing
+  , fdItalicAngle = -12.5
+  , fdDescent = Nothing
+  , fdAscent = Nothing
+  , fdLeading = Nothing
+  , fdCapHeight = Nothing
+  , fdXHeight = Nothing
+  , fdStemV = Nothing
+  , fdStemH = Nothing
+  , fdAvgWidth = Nothing
+  , fdMaxWidth = Nothing
+  , fdMissingWidth = Nothing
+  , fdCharSet = Nothing
+  }
+
+testFlagSet :: Spec
+testFlagSet = describe "flagSet" $ do
+  it "should return True when testing FixedPitch on 5" $ do
+    let res = flagSet defFD FixedPitch
+    res `shouldSatisfy` (==True)
+
+  it "should return False when testing Serif on 5" $ do
+    let res = flagSet defFD Serif
+    res `shouldSatisfy` (==False)
+
+  it "should return True when testing Symbolic on 5" $ do
+    let res = flagSet defFD Symbolic
+    res `shouldSatisfy` (==True)
+
+  it "should return False when testing Script on 5" $ do
+    let res = flagSet defFD Script
+    res `shouldSatisfy` (==False)
+
+  it "should return False when testing ForceBold on 5" $ do
+    let res = flagSet defFD ForceBold
+    res `shouldSatisfy` (==False)
+
+  it "should return True when testing ForceBold on (2^32)-1" $ do
+    let res = flagSet (defFD {fdFlags = ((2^32)::Int64)-1})  ForceBold
+    res `shouldSatisfy` (==True)
+
+  it "should return False when testing ForceBold on 0" $ do
+    let res = flagSet (defFD {fdFlags = 0}) ForceBold
+    res `shouldSatisfy` (==False)
+

--- a/content/test/Test/FontDescriptor.hs
+++ b/content/test/Test/FontDescriptor.hs
@@ -60,10 +60,14 @@ testFlagSet = describe "flagSet" $ do
     res `shouldSatisfy` (==False)
 
   it "should return True when testing ForceBold on (2^32)-1" $ do
-    let res = flagSet (defFD {fdFlags = ((2^32)::Int64)-1})  ForceBold
+    let res = flagSet (defFD {fdFlags = (power64 2 32)-1})  ForceBold
     res `shouldSatisfy` (==True)
 
   it "should return False when testing ForceBold on 0" $ do
     let res = flagSet (defFD {fdFlags = 0}) ForceBold
     res `shouldSatisfy` (==False)
 
+  where
+    power64 :: Int64 -> Int64 -> Int64
+    power64 _ 0 = 1
+    power64 b e = b * power64 b (e-1)

--- a/content/test/test.hs
+++ b/content/test/test.hs
@@ -7,6 +7,7 @@ where
 
 import qualified Test.UnicodeCMap
 import qualified Test.Parser
+import qualified Test.FontDescriptor
 
 import Test.Hspec
 
@@ -14,3 +15,4 @@ main :: IO ()
 main = hspec $ do
   Test.UnicodeCMap.spec
   Test.Parser.spec
+  Test.FontDescriptor.spec

--- a/core/lib/Pdf/Core/Object/Util.hs
+++ b/core/lib/Pdf/Core/Object/Util.hs
@@ -3,6 +3,7 @@
 
 module Pdf.Core.Object.Util
 ( intValue
+, int64Value
 , boolValue
 , realValue
 , nameValue
@@ -19,6 +20,7 @@ import Pdf.Core.Object
 import Data.ByteString (ByteString)
 import Data.Scientific (Scientific)
 import qualified Data.Scientific as Scientific
+import Data.Int (Int64)
 
 -- | Try to convert object to 'Int'
 --
@@ -33,6 +35,14 @@ intValue _ = Nothing
 -- | Specialized to prevent defaulting warning
 floatingOrInteger :: Scientific -> Either Double Int
 floatingOrInteger = Scientific.floatingOrInteger
+
+-- | Try to convert object to 'Int64'.
+--
+-- This is for cases, where according to the specs values above 2^29
+-- (Int) have to be expected.
+int64Value :: Object -> Maybe Int64
+int64Value (Number n) = Scientific.toBoundedInteger n
+int64Value _ = Nothing
 
 -- | Try to convert object to 'Bool'
 boolValue :: Object -> Maybe Bool

--- a/core/lib/Pdf/Core/Types.hs
+++ b/core/lib/Pdf/Core/Types.hs
@@ -1,0 +1,28 @@
+
+-- | Compound data structures from sec. 7.9 of PDF32000:2008
+
+module Pdf.Core.Types
+(
+  Rectangle(..),
+  rectangleFromArray
+)
+where
+
+import Pdf.Core
+import Pdf.Core.Util
+import Pdf.Core.Object.Util
+
+import qualified Data.Vector as Vector
+
+-- | Rectangle
+data Rectangle a = Rectangle a a a a
+  deriving Show
+
+-- | Create rectangle form an array of 4 numbers
+rectangleFromArray :: Array -> Either String (Rectangle Double)
+rectangleFromArray arr = do
+  res <- mapM realValue (Vector.toList arr)
+      `notice` "Rectangle should contain real values"
+  case res of
+    [a, b, c, d] -> return $ Rectangle a b c d
+    _ -> Left ("rectangleFromArray: " ++ show arr)

--- a/core/pdf-toolbox-core.cabal
+++ b/core/pdf-toolbox-core.cabal
@@ -46,6 +46,7 @@ library
                        Pdf.Core.Stream
                        Pdf.Core.Stream.Filter.Type
                        Pdf.Core.Stream.Filter.FlateDecode
+                       Pdf.Core.Types
                        Pdf.Core.XRef
                        Pdf.Core.Util
                        Pdf.Core.Writer

--- a/document/lib/Pdf/Document/FontDict.hs
+++ b/document/lib/Pdf/Document/FontDict.hs
@@ -244,7 +244,7 @@ loadFontDescriptor pdf fontDict = do
             lookupObject pdf ref
 
       fontName <- required "FontName" nameValue' fd
-      fontFamily <- optional "FontFamily" nameValue' fd
+      fontFamily <- optional "FontFamily" (fmap decodeUtf8 . stringValue) fd
       fontStretch <- optional "FontStretch" nameValue' fd
       fontWeight <- optional "FontWeight" intValue fd
       flags <- required "Flags" int64Value fd
@@ -261,7 +261,7 @@ loadFontDescriptor pdf fontDict = do
       avgWidth <- optional "AvgWidth" realValue fd
       maxWidth <- optional "MaxWidth" realValue fd
       missingWidth <- optional "MissingWidth" realValue fd
-      charSet <- optional "CharSet" nameValue' fd
+      charSet <- optional "CharSet" (fmap decodeUtf8 . stringValue) fd
 
       return $ Just $ FontDescriptor
         { fdFontName = fontName

--- a/document/lib/Pdf/Document/FontDict.hs
+++ b/document/lib/Pdf/Document/FontDict.hs
@@ -15,6 +15,7 @@ import Pdf.Core.Object
 import Pdf.Core.Object.Util
 import Pdf.Core.Exception
 import Pdf.Core.Util
+import Pdf.Core.Types
 import qualified Pdf.Core.Name as Name
 import Pdf.Content
 
@@ -28,6 +29,8 @@ import qualified Data.HashMap.Strict as HashMap
 import Control.Monad
 import Control.Exception hiding (throw)
 import qualified System.IO.Streams as Streams
+import Data.Text.Encoding (decodeUtf8)
+import qualified Data.Text as Text
 
 -- | Font subtypes
 data FontSubtype
@@ -111,10 +114,13 @@ loadFontInfoComposite pdf fontDict = do
           >>= Vector.mapM (deref pdf)
         sure $ makeCIDFontWidths arr
 
+  fontDescriptor <- loadFontDescriptor pdf descFont
+
   return $ FIComposite {
     fiCompositeUnicodeCMap = toUnicode,
     fiCompositeWidths = widths,
-    fiCompositeDefaultWidth = defaultWidth
+    fiCompositeDefaultWidth = defaultWidth,
+    fiCompositeFontDescriptor = fontDescriptor
     }
 
 loadFontInfoSimple :: Pdf -> Dict -> IO FISimple
@@ -173,11 +179,14 @@ loadFontInfoSimple pdf fontDict = do
                 `notice` "LastChar should be an integer"
         return $ Just (firstChar, lastChar, widths)
 
+  fontDescriptor <- loadFontDescriptor pdf fontDict
+
   return $ FISimple
     { fiSimpleUnicodeCMap = toUnicode
     , fiSimpleEncoding = encoding
     , fiSimpleWidths = widths
     , fiSimpleFontMatrix = scale 0.001 0.001
+    , fiSimpleFontDescriptor = fontDescriptor
     }
 
 loadEncodingDifferences :: Pdf -> Dict -> IO [(Word8, ByteString)]
@@ -222,3 +231,85 @@ loadUnicodeCMap pdf fontDict =
             Left e -> throwIO $ Corrupted ("can't parse cmap: " ++ show e) []
             Right cmap -> return $ Just cmap
         _ -> throwIO $ Corrupted "ToUnicode: not a stream" []
+
+
+loadFontDescriptor :: Pdf -> Dict -> IO (Maybe FontDescriptor)
+loadFontDescriptor pdf fontDict = do
+  case HashMap.lookup "FontDescriptor" fontDict of
+    Nothing -> return Nothing
+    Just o -> do
+      ref <- sure $ refValue o
+             `notice` "FontDescriptor should be a reference"
+      fd <- (sure . (`notice` "FontDescriptor: not a dictionary") . dictValue) =<<
+            lookupObject pdf ref
+
+      fontName <- required "FontName" nameValue' fd
+      fontFamily <- optional "FontFamily" nameValue' fd
+      fontStretch <- optional "FontStretch" nameValue' fd
+      fontWeight <- optional "FontWeight" intValue fd
+      flags <- required "Flags" int64Value fd
+      fontBBox <- optional "FontBBox"
+        (join . fmap (either (const Nothing) Just . rectangleFromArray) . arrayValue) fd
+      italicAngle <- required "ItalicAngle" realValue fd
+      ascent <- optional "Ascent" realValue fd
+      descent <- optional "Descent" realValue fd
+      leading <- optional "Leading" realValue fd
+      capHeight <- optional "CapHeight" realValue fd
+      xHeight <- optional "XHeight" realValue fd
+      stemV <- optional "StemV" realValue fd
+      stemH <- optional "StemH" realValue fd
+      avgWidth <- optional "AvgWidth" realValue fd
+      maxWidth <- optional "MaxWidth" realValue fd
+      missingWidth <- optional "MissingWidth" realValue fd
+      charSet <- optional "CharSet" nameValue' fd
+
+      return $ Just $ FontDescriptor
+        { fdFontName = fontName
+        , fdFontFamily = fontFamily
+        , fdFontStretch = fontStretch
+        , fdFontWeight = fontWeight
+        , fdFlags = flags
+        , fdFontBBox = fontBBox
+        , fdItalicAngle = italicAngle
+        , fdDescent = descent
+        , fdAscent = ascent
+        , fdLeading = leading
+        , fdCapHeight = capHeight
+        , fdXHeight = xHeight
+        , fdStemV = stemV
+        , fdStemH = stemH
+        , fdAvgWidth = avgWidth
+        , fdMaxWidth = maxWidth
+        , fdMissingWidth = missingWidth
+        , fdCharSet = charSet
+        }
+  where
+    required = requiredInDict "FontDescriptor"
+    optional = optionalInDict "FontDescriptor"
+    nameValue' = fmap (decodeUtf8 . Name.toByteString) . nameValue
+
+-- | Parse a value from a required field of a dictionary. This will
+-- raise an exception if a) the field is not present or b) the field
+-- value has a false type.
+requiredInDict :: String -- ^ a context for a failure notice
+               -> Name   -- ^ name of dictionary field
+               -> (Object -> Maybe a) -- ^ function for type-casting the object
+               -> Dict                -- ^ the dictionary
+               -> IO a
+requiredInDict context key typeFun =
+  join .
+  sure . (`notice` (context ++ ": " ++ msg ++ " should exist")) .
+  fmap (sure . (`notice` (context ++ ": " ++ msg ++ " type failure")) . typeFun) .
+  HashMap.lookup key
+  where
+    msg = Text.unpack $ decodeUtf8 $ Name.toByteString key
+
+-- | Parse a value from an optional field of a dictionary. This will
+-- raise an exception if the field value has a false type.
+optionalInDict :: String -> Name -> (Object -> Maybe a) -> Dict -> IO (Maybe a)
+optionalInDict context key typeFun =
+  maybe (return Nothing) (liftM Just) .
+  fmap (sure . (`notice` (context ++ ": " ++ msg ++ " type failure")) . typeFun) .
+  HashMap.lookup key
+  where
+    msg = Text.unpack $ decodeUtf8 $ Name.toByteString key

--- a/document/lib/Pdf/Document/FontDict.hs
+++ b/document/lib/Pdf/Document/FontDict.hs
@@ -262,7 +262,7 @@ loadFontDescriptor pdf fontDict = do
       avgWidth <- optional "AvgWidth" realValue fd
       maxWidth <- optional "MaxWidth" realValue fd
       missingWidth <- optional "MissingWidth" realValue fd
-      charSet <- optional "CharSet" nameValue' fd
+      charSet <- optional "CharSet" stringValue fd
 
       return $ Just $ FontDescriptor
         { fdFontName = fontName

--- a/document/lib/Pdf/Document/Types.hs
+++ b/document/lib/Pdf/Document/Types.hs
@@ -2,27 +2,8 @@
 -- | Various types
 
 module Pdf.Document.Types
-(
-  Rectangle(..),
-  rectangleFromArray
-)
+  ( module Pdf.Core.Types
+  )
 where
 
-import Pdf.Core
-import Pdf.Core.Util
-import Pdf.Core.Object.Util
-
-import qualified Data.Vector as Vector
-
--- | Rectangle
-data Rectangle a = Rectangle a a a a
-  deriving Show
-
--- | Create rectangle form an array of 4 numbers
-rectangleFromArray :: Array -> Either String (Rectangle Double)
-rectangleFromArray arr = do
-  res <- mapM realValue (Vector.toList arr)
-      `notice` "Rectangle should contain real values"
-  case res of
-    [a, b, c, d] -> return $ Rectangle a b c d
-    _ -> Left ("rectangleFromArray: " ++ show arr)
+import Pdf.Core.Types


### PR DESCRIPTION
- This fixes #6 

- Added FontDescriptor record and a parser for it.

- Added a test for a predicate function that evaluates the Flags in FontDescriptor.

- Use FontBBox from FontDescriptor to determine the y-coordinates of glyphs instead of hard-coded 0 and 1 in Pdf.Content.FontInfo.

- Definition of Rectangle from Pdf.Document.Types was moved to Pdf.Core.Types in order to make it reusable in core and content. Since rectangles are described in the section about common data structures of the specs next to arrays, strings and numbers, core is a good place for it.
  