### PR TITLE
Make zlib optional

### DIFF
--- a/core/lib/Pdf/Core/Stream.hs
+++ b/core/lib/Pdf/Core/Stream.hs
@@ -52,7 +52,7 @@ readStream is off = do
 --
 -- Right now it contains only FlateDecode filter
 knownFilters :: [StreamFilter]
-knownFilters = [flateDecode]
+knownFilters = catMaybes [flateDecode]
 
 -- | Raw stream content.
 -- Filters are not applyed

--- a/core/no-zlib/Pdf/Core/Stream/Filter/FlateDecode.hs
+++ b/core/no-zlib/Pdf/Core/Stream/Filter/FlateDecode.hs
@@ -1,0 +1,16 @@
+
+-- | Flate decode filter
+
+module Pdf.Core.Stream.Filter.FlateDecode
+(
+  flateDecode
+)
+where
+
+import Pdf.Core.Stream.Filter.Type
+
+-- | Vary basic implementation. Only PNG-UP prediction is implemented
+--
+-- Nothing when zlib is disabled via cabal flag
+flateDecode :: Maybe StreamFilter
+flateDecode = Nothing

--- a/core/pdf-toolbox-core.cabal
+++ b/core/pdf-toolbox-core.cabal
@@ -28,9 +28,18 @@ source-repository head
   type:                git
   location:            git://github.com/Yuras/pdf-toolbox.git
 
+flag zlib
+  description: Enable deflate support via zlib; requires that the Zlib flag be set on io-streams
+  default:             True
+  manual:              True
+
 library
   hs-source-dirs:      lib
                        compat
+  if flag(zlib)
+    hs-source-dirs:    zlib
+  else
+    hs-source-dirs:    no-zlib
   exposed-modules:     Pdf.Core
                        Pdf.Core.File
                        Pdf.Core.IO.Buffer

--- a/core/zlib/Pdf/Core/Stream/Filter/FlateDecode.hs
+++ b/core/zlib/Pdf/Core/Stream/Filter/FlateDecode.hs
@@ -24,8 +24,10 @@ import Pdf.Core.Object.Util
 import Pdf.Core.Stream.Filter.Type
 
 -- | Vary basic implementation. Only PNG-UP prediction is implemented
-flateDecode :: StreamFilter
-flateDecode = StreamFilter
+--
+-- Nothing when zlib is disabled via cabal flag
+flateDecode :: Maybe StreamFilter
+flateDecode = Just StreamFilter
   { filterName = "FlateDecode"
   , filterDecode = decode
   }


### PR DESCRIPTION
See #59 for rationale.

The difference is that:
 - I don't use `CPP`
 - Flag doesn't change the API