### PR TITLE
Add missing file to cabal package

### DIFF
--- a/document/changelog.md
+++ b/document/changelog.md
@@ -1,5 +1,7 @@
 unreleased
 
+* add missing file in test suite (#71)
+
 0.1.1
 
 * rework API

--- a/document/pdf-toolbox-document.cabal
+++ b/document/pdf-toolbox-document.cabal
@@ -11,6 +11,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 homepage:            https://github.com/Yuras/pdf-toolbox
 extra-source-files:  changelog.md
+                     test/files/nested_xobject.pdf
 description:
   Mid level tools for processing PDF files.
   .


### PR DESCRIPTION
Tests expects test file to be there. We have to mention it in
extra-source-files to make sure tests will work with the
source distribution. See #71 