### PR TITLE
Reexport Info from Pdf.Document.Info

### DIFF
--- a/document/lib/Pdf/Document/Info.hs
+++ b/document/lib/Pdf/Document/Info.hs
@@ -4,6 +4,7 @@
 
 module Pdf.Document.Info
 (
+  Info,
   infoTitle,
   infoAuthor,
   infoSubject,


### PR DESCRIPTION
Right now it's exported only from the internal module.

I.e. [here](https://hackage.haskell.org/package/pdf-toolbox-document-0.1.1/docs/Pdf-Document-Document.html#v:documentInfo) link to `Info` leads to `Pdf.Document.Internal.Types`