### PR TITLE
Limit base version

### DIFF
--- a/content/pdf-toolbox-content.cabal
+++ b/content/pdf-toolbox-content.cabal
@@ -36,7 +36,7 @@ library
                        Pdf.Content.Encoding.MacRoman
                        Pdf.Content.Encoding.PdfDoc
   other-modules:       Prelude
-  build-depends:       base >= 4.5 && < 5,
+  build-depends:       base >= 4.9 && < 5,
                        containers,
                        attoparsec >= 0.10,
                        bytestring,

--- a/core/pdf-toolbox-core.cabal
+++ b/core/pdf-toolbox-core.cabal
@@ -60,7 +60,7 @@ library
                        Pdf.Core.Util
                        Pdf.Core.Writer
   other-modules:       Prelude
-  build-depends:       base >= 4.5 && < 5,
+  build-depends:       base >= 4.9 && < 5,
                        bytestring >= 0.10.4 && < 0.12,
                        base16-bytestring >= 1,
                        io-streams,

--- a/document/pdf-toolbox-document.cabal
+++ b/document/pdf-toolbox-document.cabal
@@ -36,7 +36,7 @@ library
                        Pdf.Document.Internal.Types
                        Pdf.Document.Internal.Util
   other-modules:       Prelude
-  build-depends:       base >= 4.5 && < 5,
+  build-depends:       base >= 4.9 && < 5,
                        containers,
                        text,
                        bytestring,

--- a/viewer/pdf-toolbox-viewer.cabal
+++ b/viewer/pdf-toolbox-viewer.cabal
@@ -22,7 +22,7 @@ executable pdf-toolbox-viewer
   other-modules:       Prelude
   hs-source-dirs:      .
                        compat
-  build-depends:       base >= 4.5 && < 5,
+  build-depends:       base >= 4.9 && < 5,
                        text,
                        process,
                        directory,


### PR DESCRIPTION
Data.Semigroup was added in base-4.9

See https://matrix.hackage.haskell.org/#/package/pdf-toolbox-core/0.1.1/ghc-7.10.3@1619634950