### PR TITLE
Handle references in FontDescriptor dictionaries

### DIFF
--- a/core/lib/Pdf/Core/Types.hs
+++ b/core/lib/Pdf/Core/Types.hs
@@ -4,10 +4,12 @@
 module Pdf.Core.Types
 (
   Rectangle(..),
-  rectangleFromArray
+  rectangleFromArray,
+  rectangleToArray
 )
 where
 
+import qualified Data.Scientific as Scientific
 import Pdf.Core
 import Pdf.Core.Util
 import Pdf.Core.Object.Util
@@ -26,3 +28,7 @@ rectangleFromArray arr = do
   case res of
     [a, b, c, d] -> return $ Rectangle a b c d
     _ -> Left ("rectangleFromArray: " ++ show arr)
+
+rectangleToArray :: Rectangle Double -> Array
+rectangleToArray (Rectangle a b c d) =
+  Vector.fromList . map (Number . Scientific.fromFloatDigits) $ [a, b, c, d]

--- a/document/test/files/indirect_font_desc_fields.hs
+++ b/document/test/files/indirect_font_desc_fields.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- Generate PDF file with font descriptor containing indirect fields
+
+module Main
+(
+  main
+)
+where
+
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Vector as Vector
+import qualified Data.HashMap.Strict as HashMap
+import Control.Monad
+import qualified System.IO.Streams as Streams
+
+import Pdf.Core
+import Pdf.Core.Types
+import Pdf.Core.Writer
+
+main :: IO ()
+main = do
+  let tr = HashMap.fromList [
+        ("Size", Number $ fromIntegral $ length objects),
+        ("Root", Ref catalogRef)
+        ]
+      objects = [
+        (Dict catalog, catalogRef),
+        (Dict rootNode, rootNodeRef),
+        (Dict page, pageRef),
+        (Dict font, fontRef),
+        (Dict fontDesc, fontDescRef),
+        (Number 0, flagsRef)
+        ]
+      streams = [
+        (contentDict, contentData, contentRef),
+        (xobjDict, xobjData, xobjRef),
+        (xobj1Dict, xobj1Data, xobj1Ref)
+        ]
+      catalog = HashMap.fromList [
+        ("Type", Name "Catalog"),
+        ("Pages", Ref rootNodeRef)
+        ]
+      rootNode = HashMap.fromList [
+        ("Type", Name "Pages"),
+        ("Kids", Array $ Vector.fromList [Ref pageRef]),
+        ("Count", Number 1)
+        ]
+      page = HashMap.fromList [
+        ("Type", Name "Page"),
+        ("Parent", Ref rootNodeRef),
+        ("Contents", Ref contentRef),
+        ("Resources", Dict resourcesDict),
+        ("MediaBox", Array $ Vector.fromList [
+          Number 0,
+          Number 0,
+          Number 200,
+          Number 200
+          ])
+        ]
+      resourcesDict = HashMap.fromList [
+        ("Font", Dict $ HashMap.fromList [
+          ("F1", Ref fontRef)
+          ]),
+        ("XObject", Dict $ HashMap.fromList [
+          ("X1", Ref xobjRef)
+          ])
+        ]
+      font = HashMap.fromList [
+        ("Type", Name "Font"),
+        ("Subtype", Name "Type1"),
+        ("BaseFont", Name "Helvetica"),
+        ("FontDescriptor", Ref fontDescRef)
+        ]
+      fontDesc = HashMap.fromList [
+        ("Type", Name "FontDescriptor"),
+        ("FontName", Name "Helvetica"),
+        ("Flags", Ref flagsRef),  -- ^ It's an indirect reference!
+        ("Rectangle", Array (rectangleToArray $ Rectangle 0 0 10 10)),
+        ("ItalicAngle", Number (-10)),
+        ("Ascent", Number 8),
+        ("Descent", Number 2)
+        ]
+      xobjResourceDict = HashMap.fromList [
+        ("Font", Dict $ HashMap.fromList [
+          ("F1", Ref fontRef)
+          ]),
+        ("XObject", Dict $ HashMap.fromList [
+          ("X1", Ref xobj1Ref)
+          ])
+        ]
+      xobjDict = HashMap.fromList [
+        ("Length", Number $ fromIntegral $ BSL.length xobjData),
+        ("Type", Name "XObject"),
+        ("Subtype", Name "Form"),
+        ("Resources", Dict xobjResourceDict),
+        ("BBox", Array $ Vector.fromList [
+          Number 0,
+          Number 0,
+          Number 200,
+          Number 200
+          ])
+        ]
+      xobjData = "BT /F1 12 Tf 10 10 TD (XObject is here) Tj ET /X1 Do"
+      xobj1ResourceDict = HashMap.fromList [
+        ("Font", Dict $ HashMap.fromList [
+          ("F1", Ref fontRef)
+          ])
+        ]
+      xobj1Dict = HashMap.fromList [
+        ("Length", Number $ fromIntegral $ BSL.length xobj1Data),
+        ("Type", Name "XObject"),
+        ("Subtype", Name "Form"),
+        ("Resources", Dict xobj1ResourceDict),
+        ("BBox", Array $ Vector.fromList [
+          Number 0,
+          Number 0,
+          Number 200,
+          Number 200
+          ])
+        ]
+      xobj1Data = "BT /F1 12 Tf 50 50 TD (nested XObject is here) Tj ET"
+      contentDict = HashMap.fromList [
+        ("Length", Number $ fromIntegral $ BSL.length contentData)
+        ]
+      contentData = "BT /F1 12 Tf 100 100 TD (Hello World!!!) Tj ET /X1 Do"
+      catalogRef = R 1 0
+      rootNodeRef = R 2 0
+      pageRef = R 3 0
+      contentRef = R 4 0
+      fontRef = R 5 0
+      fontDescRef = R 6 0
+      flagsRef = R 7 0
+      xobjRef = R 8 0
+      xobj1Ref = R 9 0
+
+  writer <- makeWriter Streams.stdout
+  writeHeader writer
+  forM_ objects $ \(obj, ref) ->
+    writeObject writer ref obj
+  forM_ streams $ \(dict, dat, ref) ->
+    writeStream writer ref dict dat
+  writeXRefTable writer 0 tr

--- a/document/test/files/indirect_font_desc_fields.pdf
+++ b/document/test/files/indirect_font_desc_fields.pdf
@@ -1,0 +1,59 @@
+%PDF-1.7
+
+1 0 obj
+<</Pages 2 0 R /Type /Catalog>>
+endobj
+
+2 0 obj
+<</Count 1 /Kids [3 0 R] /Type /Pages>>
+endobj
+
+3 0 obj
+<</Parent 2 0 R /Resources <</Font <</F1 5 0 R>> /XObject <</X1 8 0 R>>>> /MediaBox [0 0 200 200] /Contents 4 0 R /Type /Page>>
+endobj
+
+5 0 obj
+<</BaseFont /Helvetica /Subtype /Type1 /FontDescriptor 6 0 R /Type /Font>>
+endobj
+
+6 0 obj
+<</Flags 7 0 R /Rectangle [0 0 10 10] /ItalicAngle -10 /FontName /Helvetica /Descent 2 /Type /FontDescriptor /Ascent 8>>
+endobj
+
+7 0 obj
+0
+endobj
+
+4 0 obj
+<</Length 53>>stream
+BT /F1 12 Tf 100 100 TD (Hello World!!!) Tj ET /X1 Do
+endstream
+endobj
+
+8 0 obj
+<</Length 52 /Resources <</Font <</F1 5 0 R>> /XObject <</X1 9 0 R>>>> /BBox [0 0 200 200] /Subtype /Form /Type /XObject>>stream
+BT /F1 12 Tf 10 10 TD (XObject is here) Tj ET /X1 Do
+endstream
+endobj
+
+9 0 obj
+<</Length 52 /Resources <</Font <</F1 5 0 R>>>> /BBox [0 0 200 200] /Subtype /Form /Type /XObject>>stream
+BT /F1 12 Tf 50 50 TD (nested XObject is here) Tj ET
+endstream
+endobj
+xref
+1 9
+0000000009 00000 n
+0000000057 00000 n
+0000000113 00000 n
+0000000503 00000 n
+0000000257 00000 n
+0000000348 00000 n
+0000000485 00000 n
+0000000604 00000 n
+0000000812 00000 n
+trailer
+<</Root 1 0 R /Size 6>>
+startxref
+997
+%%EOF

--- a/document/test/test.hs
+++ b/document/test/test.hs
@@ -50,6 +50,18 @@ main = hspec $ do
         txt `shouldBe` Just
           "\nHello World!!!\nXObject is here\nnested XObject is here"
 
+  describe "FontDescription with indirect fields" $ do
+    it "should have correct text" $ do
+      withPdfFile "test/files/indirect_font_desc_fields.pdf" $ \pdf -> do
+        doc <- document pdf
+        catalog <- documentCatalog doc
+        root <- catalogPageNode catalog
+        page <- pageNodePageByNum root 0
+        -- here timeout breaks infinite loop in case of a bug
+        txt <- timeout 5000000 $ pageExtractText page
+        txt `shouldBe` Just
+          "\nHello World!!!\nXObject is here\nnested XObject is here"
+
 -- | Generate simple PDF file for tests
 withSimpleFile :: (Handle -> IO ()) -> IO ()
 withSimpleFile action = do


### PR DESCRIPTION
This fixes a problem with a PDF I wanted to parse - various elements of the `FontDescriptor` were references rather than having the content inline.

I haven't added a test as I can't share the PDF itself (and in any case it would be a bit big) and I'm not familiar enough with the guts of PDFs to make a valid synthetic one quickly. I can spend some more time on it if it's important.

I tried to maintain the point-free style of the code in `requiredInDict` and `optionalInDict` but maybe it's getting a bit much. It took me a while to figure out the right way to do it and I'm reasonably experienced with Haskell. 

I'm also not sure whether `followRef` should work recursively, in case following the reference leads to another reference etc.