### PR TITLE
Skip comments (%… til end of line)

### DIFF
--- a/core/lib/Pdf/Core/Parsers/Object.hs
+++ b/core/lib/Pdf/Core/Parsers/Object.hs
@@ -44,13 +44,13 @@ parseDict :: Parser Dict
 parseDict = do
   void $ P.string "<<"
   dict <- many parseKey
-  P.skipSpace
+  skipSpacesAndComments
   void $ P.string ">>"
   return $ HashMap.fromList dict
 
 parseKey :: Parser (Name, Object)
 parseKey = do
-  P.skipSpace
+  skipSpacesAndComments
   key <- parseName
   val <- parseObject
   return (key, val)
@@ -60,7 +60,7 @@ parseArray :: Parser Array
 parseArray = do
   void $ P.char '['
   array <- many parseObject
-  P.skipSpace
+  skipSpacesAndComments
   void $ P.char ']'
   return $ Vector.fromList array
 
@@ -143,9 +143,9 @@ parseHexString = do
 parseRef :: Parser Ref
 parseRef = do
   obj <- P.decimal
-  P.skipSpace
+  skipSpacesAndComments
   gen <- P.decimal
-  P.skipSpace
+  skipSpacesAndComments
   void $ P.char 'R'
   return $ R obj gen
 
@@ -181,7 +181,7 @@ parseBool = P.choice [
 -- Done "1234\nendstream" Dict [(Name "Key",ONumber (NumInt 123))]
 parseTillStreamData :: Parser ()
 parseTillStreamData = do
-  P.skipSpace
+  skipSpacesAndComments
   void $ P.string "stream"
   endOfLine
 
@@ -192,7 +192,7 @@ parseTillStreamData = do
 -- Right (OName (Name "Name"))
 parseObject :: Parser Object
 parseObject = do
-  P.skipSpace
+  skipSpacesAndComments
   P.choice [
     const Null <$> P.string "null",
     Name <$> parseName,
@@ -212,13 +212,13 @@ parseObject = do
 -- Right (Ref 1 2,ONumber (NumInt 12))
 parseIndirectObject :: Parser (Ref, Object)
 parseIndirectObject = do
-  P.skipSpace
+  skipSpacesAndComments
   index <- P.decimal :: Parser Int
-  P.skipSpace
+  skipSpacesAndComments
   gen <- P.decimal :: Parser Int
-  P.skipSpace
+  skipSpacesAndComments
   void $ P.string "obj"
-  P.skipSpace
+  skipSpacesAndComments
   obj <- parseObject
   let ref = R index gen
   case obj of

--- a/core/lib/Pdf/Core/Parsers/Util.hs
+++ b/core/lib/Pdf/Core/Parsers/Util.hs
@@ -10,7 +10,7 @@ where
 
 import Data.Attoparsec.ByteString (Parser)
 import qualified Data.Attoparsec.ByteString.Char8 as P
-import Control.Applicative (many, (*>))
+import Control.Applicative (many)
 
 -- | In pdf file EOL could be \"\\n\", \"\\r\" or \"\\n\\r\"
 --
@@ -31,7 +31,7 @@ skipSpacesAndComments = do
  where
    skipComment :: Parser ()
    skipComment = do
-     P.char '%'
+     _ <- P.char '%'
      P.skipWhile notEndOfLine
      endOfLine
    notEndOfLine '\r' = False


### PR DESCRIPTION
This attempts to skip comments.

I only attempted to locate an appropriate place to embed the functionality in "core"; I have no idea if there's similar work that could stand to be done in "document", but, with the modification made just to "core", a document that caused a parsing exception (

> Corrupted "readObjectAtOffset" ["Failed reading: empty"]

) when I ran the example "unpack-and-decrypt-pdf-file" (that's not encrypted) was successfully dumped.

Which is about as much QA as I can give about how well the code will work generally. (It's a short document, so, in particular, performance might well suffer.)

I also have not the foggiest idea if this flies in the face of the standards. (There are so many, none of which I've read, so I only skimmed the wikipedia article and squinted at what [python pdfminer does](https://github.com/euske/pdfminer/blob/master/pdfminer/psparser.py#L284) and found a place where it seems like pdf-toolbox might do similarly). The most I can say is that "unpack-and-decrypt-pdf-file" still emitted the "%PDF-1.7" at the beginning of output.

With those provisos aside, recognizing that I may have already made this "unpullable", to restate what's in the commit message:

I've seen documents that contain content like

<pre>
<<\r/Name /C0L00AON24\r/Subtype /Type3 \r/Type /Font\r% Font C0L00AON\r/CharProcs 24 0 R\r/FontBBox [0.000 -4.000 29.000 30.000]\r/FontMatrix [ 1 0 0 1 0 0 ]\r/FirstChar 64\r/LastChar 249\r/Widths 25 0 R\r/Encoding 26 0 R\r/ToUnicode  27 0 R\r>> </pre>

where the "% Font C0L00AON" line causes parsing to fail.

So this commit augments `skipSpace` by skipping not only space but also anything that looks like a comment, til end of line, recursively.

At any rate, whether or not you care for this PR, I'm a very happy user of your package. Thanks a lot!