### PR TITLE
Process (by ignoring) inline images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ tmp/
 cabal.sandbox.config
 dist-newstyle/
 .ghc.environment.*
+/.envrc
+/cabal.project.local

--- a/cabal.project
+++ b/cabal.project
@@ -2,5 +2,5 @@ packages:
   core/
   content/
   document/
-  viewer/
+  -- viewer/
   examples/

--- a/content/lib/Pdf/Content/Ops.hs
+++ b/content/lib/Pdf/Content/Ops.hs
@@ -7,6 +7,7 @@ module Pdf.Content.Ops
   Op(..),
   Expr(..),
   Operator,
+  Object(..),
   toOp
 )
 where

--- a/content/lib/Pdf/Content/Parser.hs
+++ b/content/lib/Pdf/Content/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | Parse content stream
 
@@ -43,7 +44,14 @@ parseContent = do
   skipSpace
   (Parser.endOfInput >> return Nothing) <|>
     fmap Just (fmap Obj parseObject <|>
+              parseInlineImage <|>
                fmap (Op . toOp) (Parser.takeWhile1 isRegularChar))
+
+parseInlineImage :: Parser Expr
+parseInlineImage = do
+  Parser.string "ID"
+  Parser.manyTill Parser.anyChar (Parser.string "EI")
+  return $ Op Op_EI
 
 -- Treat comments as spaces
 skipSpace :: Parser ()

--- a/content/lib/Pdf/Content/Processor.hs
+++ b/content/lib/Pdf/Content/Processor.hs
@@ -89,15 +89,16 @@ initialGraphicsState = GraphicsState {
 data Span = Span
   { spGlyphs :: [Glyph]
   , spFontName :: Name
-  }
+  } deriving Show
 
 -- | Processor maintains graphics state
 data Processor = Processor {
   prState :: GraphicsState,
   prStateStack :: [GraphicsState],
   prGlyphDecoder :: GlyphDecoder,
-  prSpans :: [Span]
+  prSpans :: [Span],
   -- ^ Each element is a list of glyphs, drawn in one shot
+  prOperators :: [Operator]
   }
 
 -- | Create processor in initial state
@@ -106,7 +107,8 @@ mkProcessor = Processor {
   prState = initialGraphicsState,
   prStateStack = [],
   prGlyphDecoder = \_ _ -> [],
-  prSpans = mempty
+  prSpans = mempty,
+  prOperators = mempty
   }
 
 -- | Process one operation


### PR DESCRIPTION
I am interested in extracting text from bank statement PDFs. Some of these have inline images, which the toolkit does not currently support.
Process them, by simply ignoring in the stream, but letting the parse continue.
Also, allow exporting the raw operators, not just page glyphs.