### PR TITLE
Support bytestring 0.12.x

### DIFF
--- a/core/pdf-toolbox-core.cabal
+++ b/core/pdf-toolbox-core.cabal
@@ -61,7 +61,7 @@ library
                        Pdf.Core.Writer
   other-modules:       Prelude
   build-depends:       base >= 4.9 && < 5,
-                       bytestring >= 0.10.4 && < 0.12,
+                       bytestring >= 0.10.4 && < 0.13,
                        base16-bytestring >= 1,
                        io-streams,
                        attoparsec >= 0.12,


### PR DESCRIPTION
The tests pass, but require
`--allow-newer='gtk:bytestring'`