### PR TITLE
Fixed compilation with GHC 9.8.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc:
+          - '9.8'
           - '9.6'
           - '9.4'
           - '9.2'

--- a/document/lib/Pdf/Document/Page.hs
+++ b/document/lib/Pdf/Document/Page.hs
@@ -282,8 +282,8 @@ glyphsToText
   . List.map spGlyphs
   where
   step acc [] = acc
-  step ((Vector lx2 ly2, wasSpace), res) sp =
-    let Vector x1 y1 = glyphTopLeft (head sp)
+  step ((Vector lx2 ly2, wasSpace), res) sp@(x : _) =
+    let Vector x1 y1 = glyphTopLeft x
         Vector x2 _ = glyphBottomRight (last sp)
         Vector _ y2 = glyphTopLeft (last sp)
         space =


### PR DESCRIPTION
I got the following error when compiling with GHC 9.8.2:

```bash
$ cabal build document --with-compiler=ghc-9.8.2 --project-file=cabal_no_viewer.project

lib/Pdf/Document/Page.hs:286:38: error: [GHC-63394] [-Wx-partial, -Werror=x-partial]
    In the use of ‘head’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
    |
286 |     let Vector x1 y1 = glyphTopLeft (head sp)
```

This PR fix the problem.